### PR TITLE
Fix the issue that exception callback can not be called when sendding message aync

### DIFF
--- a/ons-core/ons-client/src/main/java/org/apache/rocketmq/ons/api/impl/rocketmq/ProducerImpl.java
+++ b/ons-core/ons-client/src/main/java/org/apache/rocketmq/ons/api/impl/rocketmq/ProducerImpl.java
@@ -192,11 +192,11 @@ public class ProducerImpl extends ONSClientAbstract implements Producer {
 
             @Override
             public void onException(Throwable e) {
-                String topic = new String(message.getTopic());
+                //String topic = new String(message.getTopic());
                 String msgId = new String(message.getMsgID());
-                ONSClientException onsEx = checkProducerException(topic, msgId, e);
+                ONSClientException onsEx = checkProducerException(message.getTopic(), msgId, e);
                 OnExceptionContext context = new OnExceptionContext();
-                context.setTopic(topic);
+                context.setTopic(message.getTopic());
                 context.setMessageId(msgId);
                 context.setException(onsEx);
                 sendCallback.onException(context);

--- a/ons-core/ons-client/src/main/java/org/apache/rocketmq/ons/api/impl/rocketmq/ProducerImpl.java
+++ b/ons-core/ons-client/src/main/java/org/apache/rocketmq/ons/api/impl/rocketmq/ProducerImpl.java
@@ -169,7 +169,13 @@ public class ProducerImpl extends ONSClientAbstract implements Producer {
             message.setMsgID(MessageClientIDSetter.getUniqID(msgRMQ));
         } catch (Exception e) {
             LOGGER.error(String.format("Send message async Exception, %s", message), e);
-            throw checkProducerException(message.getTopic(), message.getMsgID(), e);
+            //throw checkProducerException(message.getTopic(), message.getMsgID(), e);
+            ONSClientException clientException = checkProducerException(message.getTopic(), message.getMsgID(), e);
+            OnExceptionContext context = new OnExceptionContext();
+            context.setException(clientException);
+            context.setTopic(message.getTopic());
+            context.setMessageId(message.getMsgID());
+            sendCallback.onException(context);
         }
     }
 


### PR DESCRIPTION
Fix the issue that exception callback cannot be called when sendding a message aync with a null topic